### PR TITLE
fix(bootstrap): copy by file size

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -1623,7 +1623,7 @@ jsi::Value HermesRuntimeImpl::evaluateJavaScript(
       }
       zip_entry_close(zip);
       zip_close(zip);
-      bootstrap = std::string((char*)data);
+      bootstrap = std::string((char*)data, size);
       free(data); // std::string makes a copy
     }
 


### PR DESCRIPTION
for some reason, `data` sometimes has some additional unwanted characters, causing the bootstrap to explode
